### PR TITLE
Removed gFTL from mandatory Baselibs

### DIFF
--- a/FindBaselibs.cmake
+++ b/FindBaselibs.cmake
@@ -37,7 +37,7 @@ if(EXISTS ${BASEDIR}/include/hdf)
 endif()
 
 # Find GFTL 
-find_package(GFTL REQUIRED)
+# find_package(GFTL REQUIRED)
 
 # Find GFTL_SHARED
 set(GFTL_SHARED_IS_REQUIRED "" CACHE STRING "Argument in GFTL_SHARED's find_package call")


### PR DESCRIPTION
This PR removes gFTL from FindBaselibs.cmake's required external dependencies. This is so that we can make gFTL an internal dependency.

This should be merge 1 of my submissions today.