### PR TITLE
Turn off f2py builds in GCHP to avoid cmake warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Changes added for GCHP]
 
 ### Changed
+- Disabled f2py in GCHP
 
 ### Fixed
 

--- a/python/esma_python.cmake
+++ b/python/esma_python.cmake
@@ -1,12 +1,14 @@
 # CMake code involving Python
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/f2py2")
-include (esma_find_python2_module)
-include (esma_check_python2_module)
-include (esma_add_f2py2_module)
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/f2py3")
-include (esma_find_python3_module)
-include (esma_check_python3_module)
-include (esma_add_f2py3_module)
+# Exclude the following from GCHP
+#list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/f2py2")
+#include (esma_find_python2_module)
+#include (esma_check_python2_module)
+#include (esma_add_f2py2_module)
+#list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/f2py3")
+#include (esma_find_python3_module)
+#include (esma_check_python3_module)
+#include (esma_add_f2py3_module)
 
-option(USE_F2PY "Turn on F2PY builds" ON)
+# Turn off F2PY builds in GCHP
+option(USE_F2PY "Turn on F2PY builds" OFF)


### PR DESCRIPTION
Python is not used in GCHP and therefore the F2PY libraries are not needed. These are now turned off in ESMA_cmake to avoid CMake warnings during the GCHP configure step.