### PR TITLE
Include esma_add_fortran_submodules for MAPL3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Changes added for GCHP]
 
 ### Changed
+
 ### Fixed
+
 ### Removed
+
 ### Added
+- Added esma_add_fortran_submodules.cmake from ESMA_cmake v4.1.0 for MAPL3 compatibility
 
 ## [3.8.0] - 2021-Dec-16
 

--- a/esma_support/esma_add_fortran_submodules.cmake
+++ b/esma_support/esma_add_fortran_submodules.cmake
@@ -1,0 +1,33 @@
+# Function to avoid conflicts with files (in separate folders) with the same name.
+# The function is necessary for submodule files.
+
+function(esma_add_fortran_submodules)
+  set(options)
+  set(oneValueArgs TARGET SUBDIRECTORY)
+  set(multiValueArgs SOURCES)
+  cmake_parse_arguments(
+    ARG "${options}" "${oneValueArgs}"
+    "${multiValueArgs}" ${ARGN}
+  )
+
+  foreach(file ${ARG_SOURCES})
+
+    set(input ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_SUBDIRECTORY}/${file})
+    set(output ${CMAKE_CURRENT_BINARY_DIR}/${ARG_SUBDIRECTORY}_SMOD_${file})
+    set(esma_internal "esma_internal_${ARG_SUBDIRECTORY}_SMOD_${file}")
+
+    add_custom_command(
+      OUTPUT ${output}
+      COMMAND ${CMAKE_COMMAND} -E copy ${input} ${output}
+      DEPENDS ${input}
+    )
+    add_custom_target(${esma_internal}  DEPENDS ${output})
+
+    set_property(SOURCE ${output} TARGET_DIRECTORY ${ARG_TARGET} PROPERTY GENERATED 1)
+    add_dependencies(${ARG_TARGET} ${esma_internal})
+    target_sources(${ARG_TARGET} PRIVATE ${output})
+
+  endforeach()
+
+endfunction()
+

--- a/esma_support/esma_support.cmake
+++ b/esma_support/esma_support.cmake
@@ -8,6 +8,7 @@ include (esma_add_library)
 include (esma_generate_automatic_code)
 include (esma_create_stub_component)
 include (esma_fortran_generator_list)
+include (esma_add_fortran_submodules)
 
 # Testing
 include (esma_enable_tests)


### PR DESCRIPTION
This update adds a new function needed for MAPL3 compatibility. It does not break backwards compatibility with MAPL2. The feature was added in ESMA_cmake version 4.1.0 in the upstream.